### PR TITLE
Update tarball link

### DIFF
--- a/lib/init/create.js
+++ b/lib/init/create.js
@@ -29,7 +29,7 @@ var initProject = function(options, callback) {
         catch (e) {
             downloadSeed(tempZipPath, function() {
                 extract(tempZipPath, tempPath, function(){
-                    fs.copy(path.join(tempPath, 'mixed-mode-seed'), dirPath, function (err) {
+                    fs.copy(path.join(tempPath, 'engine-seed-master'), dirPath, function (err) {
                         if (err) return console.error(err);
                         if (typeof callback === 'function') {
                             return callback(null);
@@ -46,7 +46,7 @@ var initProject = function(options, callback) {
             if (!items || !items.length) {
                 downloadSeed(tempZipPath, function() {
                     extract(tempZipPath, tempPath, function() {
-                        fs.copy(path.join(tempPath, 'mixed-mode-seed'), process.cwd(), function(err) {
+                        fs.copy(path.join(tempPath, 'engine-seed-master'), process.cwd(), function(err) {
                             if (err) return console.error(err);
                             if (typeof callback === 'function') {
                                 return callback(null);
@@ -67,7 +67,7 @@ var initProject = function(options, callback) {
 
 function downloadSeed(dest, cb) {
     var file = fs.createWriteStream(dest);
-    var request = https.get('https://s3-us-west-2.amazonaws.com/code.famo.us/cli/mixed-mode-seed.tar.gz', function(response) {
+    var request = https.get('https://code.famo.us/cli/engine-seed-master.tar.gz', function(response) {
         response.pipe(file);
         file.on('finish', function() {
             file.close(cb);


### PR DESCRIPTION
The current link is pointing directly to S3 meaning we cannot get metrics from fastly. The name has also been changed to reflect the default name created by github for a tarball so that we can do the CI thang.