### PR TITLE
Ignore famous components

### DIFF
--- a/lib/framework/scaffold/templates/_gitignore
+++ b/lib/framework/scaffold/templates/_gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules
 public/build
+components/famous


### PR DESCRIPTION
No need to commit components that will be added by the build script. If people are making changes to core components they could remove this line from gitignore.
